### PR TITLE
V1.0.9.2 (#91)

### DIFF
--- a/src/componentsPages/GlobalShortages/DataOriginSection.tsx
+++ b/src/componentsPages/GlobalShortages/DataOriginSection.tsx
@@ -21,7 +21,7 @@ export const DataOriginSection = () => (
             de stocks inférieurs au niveau de stock requis.
           </p>
           <p>
-            Les MITM sont des médicaments pour lesquelles une interruption de traitement est
+            Les MITM sont des médicaments pour lesquels une interruption de traitement est
             susceptible de mettre en jeu le pronostic vital des patients à court ou moyen terme, ou
             représente une perte de chance importante pour les patients au regard de la gravité ou
             du potentiel évolutif de la maladie.

--- a/src/componentsPages/GlobalShortages/DeclarationsCausesFiguresGraphSection.tsx
+++ b/src/componentsPages/GlobalShortages/DeclarationsCausesFiguresGraphSection.tsx
@@ -31,7 +31,7 @@ export const DeclarationsCausesFiguresGraphSection = (_props: HTMLAttributes<HTM
   return (
     <div className="DeclarationCauseByYear">
       <GraphBoxSelect
-        title="Causes des signalements de ruptures et risques de rupture de stock"
+        title="Causes des déclarations de ruptures et risques de rupture de stock"
         className="max-w-full"
         yearsOptions={globalShortagesYearsOptions}
         theme="secondary-variant"

--- a/src/componentsPages/GlobalShortages/GlobalShortagesPage.tsx
+++ b/src/componentsPages/GlobalShortages/GlobalShortagesPage.tsx
@@ -28,7 +28,7 @@ export const GlobalShortagesPage = () => (
                 Qu&apos;est-ce qu&apos;un Médicament d&apos;Intérêt Thérapeutique Majeur ?
               </p>
               <p className="text-base">
-                Les MITM sont des médicaments pour lesquelles une interruption de traitement est
+                Les MITM sont des médicaments pour lesquels une interruption de traitement est
                 susceptible de mettre en jeu le pronostic vital des patients à court ou moyen terme,
                 ou représente une perte de chance importante pour les patients au regard de la
                 gravité ou du potentiel évolutif de la maladie.

--- a/src/componentsPages/GlobalShortages/RepartitionPerTherapeuticClass.tsx
+++ b/src/componentsPages/GlobalShortages/RepartitionPerTherapeuticClass.tsx
@@ -38,8 +38,8 @@ export const RepartitionPerTherapeuticClass = (_props: HTMLAttributes<HTMLDivEle
         tooltip={
           <>
             <p className="font-medium text-xl">
-              Nombre de déclarations de ruptures ou de risques de rupture de stock et nombre de médicaments par classe
-              thérapeutique
+              Nombre de déclarations de ruptures ou de risques de rupture de stock et nombre de
+              médicaments par classe thérapeutique
             </p>
             <p>
               Le Système de classification anatomique, thérapeutique et chimique (en anglais :
@@ -50,13 +50,13 @@ export const RepartitionPerTherapeuticClass = (_props: HTMLAttributes<HTMLDivEle
               caractéristiques thérapeutiques et chimiques.
             </p>
             <p>
-              L&apos;histogramme vert représente le nombre de déclarations reçues par classe thérapeutique
-              (classification ATC). L&apos;histogramme bleu indique le nombre de présentations de
-              médicaments (une présentation correspond à un conditionnement précis d&apos;un
-              médicament, par exemple une boîte de 30 gélules et une boîte de 90 gélules d&apos;un
-              même médicament sont deux présentations différentes) que contient la classe. Dans leur
-              globalité, ces graphiques permettent d&apos;apprécier le nombre de déclarations reçues par
-              rapport au nombre de médicaments disponibles.
+              L&apos;histogramme vert représente le nombre de déclarations reçues par classe
+              thérapeutique (classification ATC). L&apos;histogramme bleu indique le nombre de
+              présentations de médicaments (une présentation correspond à un conditionnement précis
+              d&apos;un médicament, par exemple une boîte de 30 gélules et une boîte de 90 gélules
+              d&apos;un même médicament sont deux présentations différentes) que contient la classe.
+              Dans leur globalité, ces graphiques permettent d&apos;apprécier le nombre de
+              déclarations reçues par rapport au nombre de médicaments disponibles.
             </p>
           </>
         }
@@ -67,8 +67,9 @@ export const RepartitionPerTherapeuticClass = (_props: HTMLAttributes<HTMLDivEle
               : [];
 
           const therapeuticRepartitionForSelectedYear = shortagesTypeRepForSelectedYear
-            ? shortagesTypeRepForSelectedYear
-                .sort((a, b) => (a.label && b.label ? a.label.localeCompare(b.label) : 1))
+            ? shortagesTypeRepForSelectedYear.sort((a, b) =>
+                a.label && b.label ? a.label.localeCompare(b.label) : 1
+              )
             : [];
 
           const labels = therapeuticRepartitionForSelectedYear
@@ -77,7 +78,7 @@ export const RepartitionPerTherapeuticClass = (_props: HTMLAttributes<HTMLDivEle
             .filter(Boolean) as string[];
 
           const datasetBar: ChartDataset<'bar'> = {
-            label: 'Nombre de signalements',
+            label: 'Nombre de déclarations',
             backgroundColor: tailwindPaletteConfig.darkGreen[400],
             borderColor: tailwindPaletteConfig.darkGreen[400],
             data: therapeuticRepartitionForSelectedYear?.map((e) => e?.reportsCount ?? 0),
@@ -96,7 +97,7 @@ export const RepartitionPerTherapeuticClass = (_props: HTMLAttributes<HTMLDivEle
                 className="my-8"
                 labels={labels}
                 dataset={datasetBar}
-                leftLegend="Nombre de signalements"
+                leftLegend="Nombre de déclarations"
               />
 
               <BarChart

--- a/src/componentsPages/GlobalStatistic/GlobalStatisticPage.tsx
+++ b/src/componentsPages/GlobalStatistic/GlobalStatisticPage.tsx
@@ -16,6 +16,8 @@ import { GraphBoxSelect } from '../../components/GraphBoxSelect';
 import { Accordion } from '../../components/Accordion';
 import GlobStatSvg from '../../assets/pictos/sick_transparent_person.svg';
 import { Tooltip } from '../../components/Tooltip';
+import { CardWithImage } from '../../components/CardWithImage';
+import CommuniqueSvg from '../../assets/pictos/communique.svg';
 import { useGlobalDecPageContext } from '../../contexts/GlobaleDecPageContext';
 import { useMemo } from 'react';
 import { buildSortedRangeData } from '../../utils/entities';
@@ -54,9 +56,78 @@ const SectionDemography = () => {
         //   </div>
         // }
       >
-        Cumul de toutes les déclarations d&apos;effets indésirables suspectés, tous médicaments
-        confondus, reçues par les centres régionaux de pharmacovigilance sur la période considérée
+        {exposition?.maxYear && exposition?.minYear
+          ? `Cumul de toutes les déclarations d'effets indésirables suspectés, tous médicaments
+          confondus, reçues par les centres régionaux de pharmacovigilance sur la période 
+          ${exposition.minYear} - ${exposition.maxYear}`
+          : 'Période des données issues non renseignée'}
       </BoxInfo>
+
+      <Accordion
+        className="shadow rounded-lg"
+        theme="secondary-variant"
+        classNameTitle="text-dark-green-900"
+        title="Comment sont calculés ces indicateurs ? D’où viennent ces données ?"
+      >
+        <p>
+          La pharmacovigilance est la surveillance, l’évaluation, la prévention et la gestion du
+          risque d’effet indésirable résultant de l’utilisation des médicaments. Elle s’exerce en
+          permanence, avant et après la commercialisation des médicaments, et constitue un élément
+          essentiel du contrôle de la sécurité des médicaments.
+        </p>
+        <p>
+          Afin de respecter la confidentialité des données des patients, si un critère (âge,
+          sexe,...) représente moins de 11 cas, l&apos;information ne sera pas affichée avec ce
+          niveau de détail. Les données manquantes ne sont pas affichées. Tenant compte de ces deux
+          conditions, le total des pourcentages n&apos;atteint pas toujours les 100%.
+        </p>
+
+        <p>
+          Ces données sont issues de la Base Nationale de Pharmacovigilance (BNPV), qui est la base
+          de données de l&apos;ANSM alimentée par les Centres Régionaux de Pharmacovigilance (CRPV).
+          Elle inclut l&apos;ensemble des déclarations suspectées comme étant en lien avec
+          l&apos;usage d&apos;un ou plusieurs médicaments. Ces dernières sont notifiées par les
+          professionnels de santé ou par les patients et association agréées via un portail dédié:{' '}
+          <a
+            rel="external noreferrer"
+            target="_blank"
+            href="https://signalement.social-sante.gouv.fr"
+            className="text-primary"
+          >
+            https://signalement.social-sante.gouv.fr
+          </a>
+        </p>
+
+        <p className="text-md font-medium mt-8">
+          Précision sur les déclarations d’effets indésirables
+        </p>
+
+        <CardWithImage contentClassName="!p-0" image={<CommuniqueSvg />}>
+          <p>
+            La déclaration en pharmacovigilance permet la détection de signal. Ces données
+            déclaratives ne permettent pas d&apos;estimer la fréquence des effets indésirables, les
+            déclarations ne sont ni exhaustives ni représentatives dans la population.
+          </p>
+
+          <p>
+            Le nombre exact de patients traités n&apos;étant pas connu sur la période de déclaration
+            l&apos;établissement de statistiques de fréquence d&apos;effets indésirables n&apos;est
+            pas possible à partir des données de déclaration.
+          </p>
+          <p>
+            Pour plus d’information, consultez:{' '}
+            <a
+              rel="external noreferrer"
+              target="_blank"
+              href="https://ansm.sante.fr/page/la-surveillance-renforcee-des-medicaments"
+              className="text-primary"
+            >
+              https://ansm.sante.fr/page/la-surveillance-renforcee-des-medicaments
+            </a>
+          </p>
+        </CardWithImage>
+      </Accordion>
+
       <SectionTitle
         title="Caractéristiques des patients"
         subTitle={
@@ -157,7 +228,8 @@ const SectionSeriousEffect = () => {
                   effet indésirable grave est un effet indésirable létal, ou susceptible de mettre
                   la vie en danger, ou entraînant une invalidité ou une incapacité importantes ou
                   durables, ou provoquant ou prolongeant une hospitalisation, ou se manifestant par
-                  une anomalie ou une malformation congénitale.
+                  une anomalie ou une malformation congénitale. Sont aussi pris en compte les
+                  déclarations d&apos;effets indésirables ayant été jugés graves par le déclarant.
                 </p>
                 <p>
                   Les effets graves ont tendance à être plus déclarés que les cas non graves. Les
@@ -177,7 +249,7 @@ const SectionSeriousEffect = () => {
 
         <div className="flex-1">
           <GraphBox
-            title="Détail des déclarations d'effets indésirables graves"
+            title="Répartition par cause de gravité"
             className="h-full max-w-[100%]"
             tooltip={
               <>
@@ -190,7 +262,7 @@ const SectionSeriousEffect = () => {
                 </p>
                 <p>
                   La catégorie &quot;Autre&quot; correspond aux déclarations d&apos;effets
-                  indésirables ayant été jugées comme grave par le déclarant, mais ne rentrant pas
+                  indésirables ayant été jugés comme grave par le déclarant, mais ne rentrant pas
                   dans les catégories listées comme étant graves selon la définition réglementaire
                   de gravité en pharmacovigilance.
                 </p>
@@ -200,7 +272,7 @@ const SectionSeriousEffect = () => {
             <BarChartRepartition
               className="h-64 w-full flex justify-center items-center"
               data={globalDecSeriousEffectsRep}
-              dataLabel="Détail des déclarations d'effets indésirables graves"
+              dataLabel="Répartition par cause de gravité"
               theme="green-full"
             />
           </GraphBox>

--- a/src/componentsPages/Speciality/SpecialityPage.tsx
+++ b/src/componentsPages/Speciality/SpecialityPage.tsx
@@ -489,7 +489,8 @@ const SectionSideEffects = () => {
         <p>
           Afin de respecter la confidentialité des données des patients, si un critère (âge,
           sexe,...) représente moins de 11 cas, l&apos;information ne sera pas affichée avec ce
-          niveau de détail.
+          niveau de détail. Les données manquantes ne sont pas affichées. Tenant compte de ces deux
+          conditions, le total des pourcentages n&apos;atteint pas toujours les 100%.
         </p>
 
         <p>
@@ -598,7 +599,7 @@ const SectionRisksShortageHistory = () => {
           <div className="p-4 border border-grey-100 rounded-lg bg-white">
             <div className="text-primary font-medium">
               <span>{`${numberWithThousand(count)} ${
-                count === 1 ? 'déclaration' : 'déclarations'
+                count === 1 ? 'déclaration' : 'déclarations concernant la substance active'
               }`}</span>
             </div>
             <div className="pt-6">

--- a/src/componentsPages/Substance/SubstancePage.tsx
+++ b/src/componentsPages/Substance/SubstancePage.tsx
@@ -16,6 +16,8 @@ import WomanIllustration from '../../assets/pictos/woman_illustration.svg';
 import { PieChartRepartition } from '../../components/Charts/PieChartRepartition';
 import { GraphBox } from '../../components/GraphBox/GraphBox';
 import { GraphFigure } from '../../components/GraphFigure';
+import { CardWithImage } from '../../components/CardWithImage';
+import CommuniqueSvg from '../../assets/pictos/communique.svg';
 import { SectionTitle } from '../../components/SectionTitle';
 import { useMemo, useRef } from 'react';
 import { buildSortedRangeData } from '../../utils/entities';
@@ -45,8 +47,8 @@ const SectionOneGlobalInformation = () => {
       <Accordion
         className="shadow"
         theme="secondary"
-        title="Comment sont calculés ces indicateurs ? D’où viennent ces données ?"
         classNameTitle="text-secondary"
+        title="Comment sont calculés ces indicateurs ? D’où viennent ces données ?"
       >
         <p>
           Estimations obtenues à partir des données Open-Medic portant sur le nombre de patients
@@ -153,7 +155,7 @@ const SectionSideEffects = () => {
   const { sideEffects } = currentEntity;
 
   return (
-    <div className="min-h-screen text-center">
+    <div className="min-h-screen">
       <SectionTitle
         title="Déclarations d’effets indésirables suspectés de la substance active"
         subTitle={
@@ -162,6 +164,72 @@ const SectionSideEffects = () => {
             : 'Période des données issues non renseignée'
         }
       />
+
+      <Accordion
+        className="shadow rounded-lg"
+        classNameTitle="text-secondary"
+        theme="secondary"
+        title="Comment sont calculés ces indicateurs ? D’où viennent ces données ?"
+      >
+        <p>
+          La pharmacovigilance est la surveillance, l’évaluation, la prévention et la gestion du
+          risque d’effet indésirable résultant de l’utilisation des médicaments. Elle s’exerce en
+          permanence, avant et après la commercialisation des médicaments, et constitue un élément
+          essentiel du contrôle de la sécurité des médicaments.
+        </p>
+        <p>
+          Afin de respecter la confidentialité des données des patients, si un critère (âge,
+          sexe,...) représente moins de 11 cas, l&apos;information ne sera pas affichée avec ce
+          niveau de détail. Les données manquantes ne sont pas affichées. Tenant compte de ces deux
+          conditions, le total des pourcentages n&apos;atteint pas toujours les 100%.
+        </p>
+
+        <p>
+          Ces données sont issues de la Base Nationale de Pharmacovigilance (BNPV), qui est la base
+          de données de l&apos;ANSM alimentée par les Centres Régionaux de Pharmacovigilance (CRPV).
+          Elle inclut l&apos;ensemble des déclarations suspectées comme étant en lien avec
+          l&apos;usage d&apos;un ou plusieurs médicaments. Ces dernières sont notifiées par les
+          professionnels de santé ou par les patients et association agréées via un portail dédié:{' '}
+          <a
+            rel="external noreferrer"
+            target="_blank"
+            href="https://signalement.social-sante.gouv.fr"
+            className="text-primary"
+          >
+            https://signalement.social-sante.gouv.fr
+          </a>
+        </p>
+
+        <p className="text-md font-medium mt-8">
+          Précision sur les déclarations d’effets indésirables
+        </p>
+
+        <CardWithImage contentClassName="!p-0" image={<CommuniqueSvg />}>
+          <p>
+            La déclaration en pharmacovigilance permet la détection de signal. Ces données
+            déclaratives ne permettent pas d&apos;estimer la fréquence des effets indésirables, les
+            déclarations ne sont ni exhaustives ni représentatives dans la population.
+          </p>
+
+          <p>
+            Le nombre exact de patients traités n&apos;étant pas connu sur la période de déclaration
+            l&apos;établissement de statistiques de fréquence d&apos;effets indésirables n&apos;est
+            pas possible à partir des données de déclaration.
+          </p>
+          <p>
+            Pour plus d’information, consultez:{' '}
+            <a
+              rel="external noreferrer"
+              target="_blank"
+              href="https://ansm.sante.fr/page/la-surveillance-renforcee-des-medicaments"
+              className="text-primary"
+            >
+              https://ansm.sante.fr/page/la-surveillance-renforcee-des-medicaments
+            </a>
+          </p>
+        </CardWithImage>
+      </Accordion>
+
       <SubstanceSideEffects substance={currentEntity} />
     </div>
   );

--- a/src/componentsPages/Substance/SubstanceSideEffects.tsx
+++ b/src/componentsPages/Substance/SubstanceSideEffects.tsx
@@ -122,9 +122,9 @@ export const SubstanceSideEffects = ({
         className="my-8"
       >
         Nombre cumulé de déclarations d&lsquo;effets indésirables suspectés{' '}
-        {substance.exposition?.openMedicPeriod?.minYear &&
-          substance.exposition?.openMedicPeriod?.maxYear &&
-          `sur la période ${substance.exposition?.openMedicPeriod?.minYear} ${substance.exposition?.openMedicPeriod?.maxYear}`}
+        {substance.sideEffects?.bnpvPeriod?.minYear &&
+          substance.sideEffects?.bnpvPeriod?.maxYear &&
+          `sur la période ${substance.sideEffects?.bnpvPeriod?.minYear} - ${substance.sideEffects?.bnpvPeriod?.maxYear}`}
       </BoxInfo>
 
       <div className="flex flex-shrink flex-col md:flex-row gap-8 mb-8 m-auto">
@@ -215,6 +215,7 @@ export const SubstanceSideEffects = ({
       <Accordion
         title="Comment sont calculés ces indicateurs ? D’où viennent ces données ?"
         theme="secondary"
+        classNameTitle="text-secondary"
         className="my-8 shadow"
       >
         <p>

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -45,11 +45,14 @@ const SectionGuichetUsager = () => (
       des patients, professionnels de santé, industriels, et plus largement du grand public…
     </p>
     <p>
-      Si votre question concerne les effets indésirables, les erreurs médicamenteuses, les ruptures
-      de stocks ou tout autre demande concernant data.ansm, nous vous invitons à remplir le
-      formulaire, en sélectionnant « data.ansm.sante.fr » dans la question « Votre demande concerne
-      ». Il sera directement adressé à notre guichet usager qui le traitera dans les meilleurs
-      délais.
+      Si votre question concerne les effets indésirables, les erreurs médicamenteuses ou les
+      ruptures de stocks, nous vous invitons à remplir le formulaire en cliquant sur le bouton
+      ci-dessous. Il sera directement adressé à notre guichet usager qui le traitera dans les
+      meilleurs délais.
+    </p>
+    <p>
+      Si votre question porte sur le site data.ansm.sante.fr, vous pouvez le préciser en
+      sélectionnant « data.ansm.sante.fr » à la question « Votre demande concerne » du formulaire.
     </p>
     <p className="mb-8">
       Il est important de ne pas transmettre des données médicales non nécessaires au traitement de

--- a/src/pages/mentions-legales.tsx
+++ b/src/pages/mentions-legales.tsx
@@ -166,12 +166,16 @@ const SectionAnnoucement = () => (
 const SectionDataProtect = () => (
   <Section title="Protection des données à caractère personnel">
     <div className="py-4">
-      Les données publiées sur le site data.ansm sont issues de bases de données de l&apos;ANSM et
-      d&apos;autres institutions françaises (Cnam) et ont fait l&apos;objet d&apos;une
-      pseudonymisation afin de garantir la protection de la vie privée des patients. Pour cela,
-      seules des données agrégées sont mises en ligne. Lorsqu&apos;un effet indésirable concerne
-      moins de 11 patients, le nombre de personnes concernées n&apos;est pas affiché, afin
-      d&apos;éviter toute réidentification possible des patients
+      Les données publiées sur le site{' '}
+      <Link href="/">
+        <a>data.ansm.sante.fr</a>
+      </Link>{' '}
+      sont issues de bases de données de l&apos;ANSM et d&apos;autres institutions françaises (Cnam)
+      et ont fait l&apos;objet d&apos;une pseudonymisation afin de garantir la protection de la vie
+      privée des patients. Pour cela, seules des données agrégées sont mises en ligne.
+      Lorsqu&apos;un effet indésirable concerne moins de 11 patients, le nombre de personnes
+      concernées n&apos;est pas affiché, afin d&apos;éviter toute réidentification possible des
+      patients
     </div>
   </Section>
 );

--- a/src/utils/iconsMapping.tsx
+++ b/src/utils/iconsMapping.tsx
@@ -362,7 +362,7 @@ export const getRuptureCauseIcon = (name: string) => {
     case 'Coronavirus':
       return <Coronavirus className="w-24 md:w-32" />;
     case "Défaut d'approvisionnement en Matière Première":
-      return <AutreSvg className="w-24 md:w-32" />;
+      return <DefautApprovisionnementMpSvg className="w-24 md:w-32" />;
     case 'Problème qualité : Analyse non conforme':
       return <AnalyseNonConformeSvg className="w-24 md:w-32" />;
     case "Défaut d'approvisionnement en Article de Conditionnement":


### PR DESCRIPTION
* DATS-373 : get bnpv period instead of openmedic period below declarations number

* feat: add explanation when percentages sum not 100%

* feat: add comment for other categorie of gravity cause in global pv page

* DATS-374 : replace data.ansm with data.ansm.sante.fr in mentions legales page

* DATS-375 : add data period in first block in gloabl pv page

* DATS-376 : contacts page, distinction between site and other subjects

* DATS-379 : add accodion info pv in substance and gloabl pv pages

* DATS-380 : page speciality complete title histo shortage

* DATS-378 : change icon in cause shortages in global shortages page