### PR TITLE
Evolutions simples de data.ansm

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -322,7 +322,9 @@ type RupturesTotalActionPerYear {
 
 type Period {
     minYear: Int!
+    minMonth: String
     maxYear: Int!
+    maxMonth: String
 }
 
 type ShortagesPerYear {

--- a/schema.graphql
+++ b/schema.graphql
@@ -144,8 +144,8 @@ type SpecialityAssociatedShortage {
     date: String
     year: Int
     cis: ShortageCis
-
-    cause: SpecialityRuptureCause
+    cause: String
+    
     classification:  String @capitalize
 }
 

--- a/scripts_ORDEI/README.md
+++ b/scripts_ORDEI/README.md
@@ -13,5 +13,5 @@ Un travail d'analyse, de croisement et d'aggrégation de ces données a été r�
 
 ### Données d'utilisation des médicaments
 
-Afin de relativiser le nombre de déclarations d'effets indésirables suspectés d’être dus à un médicament, le niveau d'utilisation des médicaments a été estimé à partir des données de la Caisse Nationale de l'Assurance Maladie : OpenMedic (https://assurance-maladie.ameli.fr/etudes-et-donnees/open-medic-base-complete-depenses-medicaments).
+Afin de relativiser le nombre de déclarations d'effets indésirables suspectés d’être dus à un médicament, le niveau d'utilisation des médicaments a été estimé à partir des données de la Caisse Nationale de l'Assurance Maladie : OpenMedic (https://assurance-maladie.ameli.fr/etudes-et-donnees/open-medic-depenses-beneficiaires-medicaments).
 Ces données annuelles ont été cumulées et agrégées par spécialité et par substance.

--- a/src/api/datasources/postgres/postgresOperations.ts
+++ b/src/api/datasources/postgres/postgresOperations.ts
@@ -36,6 +36,7 @@ import {
   getCisPharmaFormType,
   getMedicalErrorApparitionStep,
   getPublicationsTypeLabel,
+  getMonthName,
 } from '../../utils/mapping';
 import { roundFloat } from '../../utils/format';
 
@@ -1012,7 +1013,9 @@ export class PostgresOperations {
 
     return minDate && maxDate
       ? {
+          minMonth: getMonthName(minDate.getMonth() + 1),
           minYear: minDate.getFullYear(),
+          maxMonth: getMonthName(maxDate.getMonth() + 1),
           maxYear: maxDate.getFullYear(),
         }
       : null;

--- a/src/api/datasources/postgres/postgresOperations.ts
+++ b/src/api/datasources/postgres/postgresOperations.ts
@@ -368,8 +368,6 @@ export class PostgresOperations {
       .where('sa.mp_id', '=', cisId)
       .leftJoin('shortages_histo as sh', 'sh.mp_id', 'sa.mp_associated_id')
       .leftJoin('shortages_classes as sc', 'sc.id', 'sh.classification_id')
-      .leftJoin('shortages_causes as sca', 'sca.id', 'sh.cause_id')
-      .leftJoin('shortages_causes_types as sct', 'sct.id', 'sca.cause_id')
       .leftJoin('medicinal_products as mp', 'mp.id', 'sh.mp_id')
       .orderBy('sh.date', 'desc')
 
@@ -383,12 +381,9 @@ export class PostgresOperations {
         'sh.state',
         'sh.date',
         'sh.year',
+        'sh.cause',
         // classes
         'sc.classification',
-        //cause
-        'sct.id as causeId',
-        'sct.type as causeType',
-        'sct.definition as causeDefinition',
       ])
       .execute();
 
@@ -403,11 +398,9 @@ export class PostgresOperations {
         state,
         date,
         year,
+        cause,
         // classes
         classification,
-        // cause
-        causeType,
-        causeDefinition,
       } = row;
 
       return cisId
@@ -424,10 +417,7 @@ export class PostgresOperations {
               date: date?.toLocaleDateString(),
               year: Number(year),
               classification,
-              cause: {
-                type: causeType,
-                definition: causeDefinition,
-              },
+              cause,
             },
           ]
         : carry;

--- a/src/api/datasources/postgres/postgresOperations.ts
+++ b/src/api/datasources/postgres/postgresOperations.ts
@@ -376,7 +376,7 @@ export class PostgresOperations {
       .select([
         //cis
         'mp.id as cisId',
-        'mp.name as cisName',
+        'sh.name as cisName',
         'mp.cis as cisCode',
         // history
         'sh.num',

--- a/src/api/datasources/postgres/schema.introspection.ts
+++ b/src/api/datasources/postgres/schema.introspection.ts
@@ -362,7 +362,7 @@ export type ShortagesHisto = {
   name: string | null;
   mp_id: number | null;
   classification_id: number | null;
-  cause_id: number | null;
+  cause: string | null;
 };
 
 export type ShortagesLink = {

--- a/src/api/graphql/__generated__/generated-types.ts
+++ b/src/api/graphql/__generated__/generated-types.ts
@@ -394,7 +394,7 @@ export type Speciality = {
 
 export type SpecialityAssociatedShortage = {
   __typename?: 'SpecialityAssociatedShortage';
-  cause?: Maybe<SpecialityRuptureCause>;
+  cause?: Maybe<Scalars['String']>;
   cis?: Maybe<ShortageCis>;
   classification?: Maybe<Scalars['String']>;
   date?: Maybe<Scalars['String']>;
@@ -1276,7 +1276,7 @@ export type SpecialityAssociatedShortageResolvers<
   ContextType = ContextValue,
   ParentType extends ResolversParentTypes['SpecialityAssociatedShortage'] = ResolversParentTypes['SpecialityAssociatedShortage']
 > = {
-  cause?: Resolver<Maybe<ResolversTypes['SpecialityRuptureCause']>, ParentType, ContextType>;
+  cause?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   cis?: Resolver<Maybe<ResolversTypes['ShortageCis']>, ParentType, ContextType>;
   classification?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   date?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/src/api/graphql/__generated__/generated-types.ts
+++ b/src/api/graphql/__generated__/generated-types.ts
@@ -199,7 +199,9 @@ export type MutationLoginArgs = {
 
 export type Period = {
   __typename?: 'Period';
+  maxMonth?: Maybe<Scalars['String']>;
   maxYear: Scalars['Int'];
+  minMonth?: Maybe<Scalars['String']>;
   minYear: Scalars['Int'];
 };
 
@@ -1005,7 +1007,9 @@ export type PeriodResolvers<
   ContextType = ContextValue,
   ParentType extends ResolversParentTypes['Period'] = ResolversParentTypes['Period']
 > = {
+  maxMonth?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   maxYear?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  minMonth?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   minYear?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/src/api/utils/mapping.ts
+++ b/src/api/utils/mapping.ts
@@ -172,3 +172,34 @@ export const getPublicationsTypeLabel = (publishTypeId: number) => {
       return 'Autre';
   }
 };
+
+export const getMonthName = (monthNumber: number) => {
+  switch (monthNumber) {
+    case 1:
+      return 'Janvier';
+    case 2:
+      return 'Février';
+    case 3:
+      return 'Mars';
+    case 4:
+      return 'Avril';
+    case 5:
+      return 'Mai';
+    case 6:
+      return 'Juin';
+    case 7:
+      return 'Juillet';
+    case 8:
+      return 'Août';
+    case 9:
+      return 'Septembre';
+    case 10:
+      return 'Octobre';
+    case 11:
+      return 'Novembre';
+    case 12:
+      return 'Décembre';
+    default:
+      return 'Autre';
+  }
+};

--- a/src/components/KPIBoxProgression.tsx
+++ b/src/components/KPIBoxProgression.tsx
@@ -39,7 +39,7 @@ export const KPIBoxProgression = ({
       </div>
       <div>{title}</div>
     </div>
-    <div className="percentageNumber">
+    {/* <div className="percentageNumber">
       <div className={classNames('font-medium text-2xl md:text-3xl', numberColor)}>{percent} %</div>
       <div>{percentageTitle}</div>
     </div>
@@ -54,6 +54,6 @@ export const KPIBoxProgression = ({
           }}
         />
       </div>
-    </div>
+    </div> */}
   </div>
 );

--- a/src/componentsPages/Speciality/ShortageHistoryItem.tsx
+++ b/src/componentsPages/Speciality/ShortageHistoryItem.tsx
@@ -13,7 +13,7 @@ export const ShortageHistoryItem = ({
 }) => (
   <div className="flex flex-col gap-1">
     <div className="flex items-center">
-      <span className="flex-1 uppercase text-sm">Présentation du médicament</span>
+      <span className="flex-1 uppercase text-sm">Médicament</span>
       <span className="flex-1">{shortageItem.cis?.name}</span>
     </div>
     <div className="flex items-center">

--- a/src/componentsPages/Speciality/ShortageHistoryItem.tsx
+++ b/src/componentsPages/Speciality/ShortageHistoryItem.tsx
@@ -29,7 +29,7 @@ export const ShortageHistoryItem = ({
       </div>
     </div>
     <div className="flex items-center">
-      <span className="flex-1 uppercase text-sm">Date de début de la difficulté</span>
+      <span className="flex-1 uppercase text-sm">Date de déclaration</span>
       <span className="flex-1">{formatDate(shortageItem?.date ?? '')}</span>
     </div>
     {/* eslint-disable-next-line no-warning-comments */}

--- a/src/componentsPages/Speciality/ShortageHistoryItem.tsx
+++ b/src/componentsPages/Speciality/ShortageHistoryItem.tsx
@@ -25,7 +25,7 @@ export const ShortageHistoryItem = ({
         <span className="uppercase text-sm">Cause</span>
       </div>
       <div className="flex-1 flex flex-col gap-1">
-        <span>{shortageItem?.cause?.type}</span>
+        <span>{shortageItem?.cause}</span>
       </div>
     </div>
     <div className="flex items-center">

--- a/src/componentsPages/Speciality/SpecialityPage.tsx
+++ b/src/componentsPages/Speciality/SpecialityPage.tsx
@@ -580,9 +580,11 @@ const SectionRisksShortageHistory = () => {
       <SectionTitle
         title="Historique des déclarations de ruptures de stock et de risques de rupture de stock clôturées"
         subTitle={
+          currentEntity?.shortagesHistory?.trustMedPeriod?.minMonth &&
           currentEntity?.shortagesHistory?.trustMedPeriod?.maxYear &&
+          currentEntity?.shortagesHistory?.trustMedPeriod?.maxMonth &&
           currentEntity?.shortagesHistory?.trustMedPeriod?.minYear
-            ? `Données issues de la période mai ${currentEntity?.shortagesHistory?.trustMedPeriod?.minYear} - ${currentEntity?.shortagesHistory?.trustMedPeriod?.maxYear}`
+            ? `Données issues de la période ${currentEntity?.shortagesHistory?.trustMedPeriod?.minMonth} ${currentEntity?.shortagesHistory?.trustMedPeriod?.minYear} - ${currentEntity?.shortagesHistory?.trustMedPeriod?.maxMonth} ${currentEntity?.shortagesHistory?.trustMedPeriod?.maxYear}`
             : 'Période des données issues non renseignée'
         }
       />

--- a/src/componentsPages/Speciality/SpecialityPage.tsx
+++ b/src/componentsPages/Speciality/SpecialityPage.tsx
@@ -199,9 +199,9 @@ const SectionTreatedPatients = () => {
             rel="external noreferrer"
             target="_blank"
             className="text-primary"
-            href="https://assurance-maladie.ameli.fr/etudes-et-donnees/open-medic-base-complete-depenses-medicaments"
+            href="https://assurance-maladie.ameli.fr/etudes-et-donnees/open-medic-depenses-beneficiaires-medicaments"
           >
-            https://assurance-maladie.ameli.fr/etudes-et-donnees/open-medic-base-complete-depenses-medicaments
+            https://assurance-maladie.ameli.fr/etudes-et-donnees/open-medic-depenses-beneficiaires-medicaments
           </a>
         </p>
         <p>

--- a/src/componentsPages/Speciality/SpecialityPage.tsx
+++ b/src/componentsPages/Speciality/SpecialityPage.tsx
@@ -582,7 +582,7 @@ const SectionRisksShortageHistory = () => {
         subTitle={
           currentEntity?.shortagesHistory?.trustMedPeriod?.maxYear &&
           currentEntity?.shortagesHistory?.trustMedPeriod?.minYear
-            ? `Données issues de la période ${currentEntity?.shortagesHistory?.trustMedPeriod?.minYear} - ${currentEntity?.shortagesHistory?.trustMedPeriod?.maxYear}`
+            ? `Données issues de la période mai ${currentEntity?.shortagesHistory?.trustMedPeriod?.minYear} - ${currentEntity?.shortagesHistory?.trustMedPeriod?.maxYear}`
             : 'Période des données issues non renseignée'
         }
       />

--- a/src/componentsPages/Speciality/SpecialityPage.tsx
+++ b/src/componentsPages/Speciality/SpecialityPage.tsx
@@ -74,7 +74,7 @@ const SectionOneGlobalInformation = () => {
           <span>{currentEntity.atc?.name}</span> - <span>{currentEntity.atc?.code}</span>
         </div>
       )}
-      {currentEntity.commercialisationState && (
+      {/* {currentEntity.commercialisationState && (
         <div className="sectionPart mt-4 mb-8">
           <h5>État de commercialisation</h5>
           <span
@@ -88,7 +88,7 @@ const SectionOneGlobalInformation = () => {
             {currentEntity.commercialisationState}
           </span>
         </div>
-      )}
+      )} */}
       {currentEntity.laboratory && (
         <div className="sectionPart mt-4 mb-8">
           <h5>Laboratoire</h5>

--- a/src/componentsPages/Substance/SubstancePage.tsx
+++ b/src/componentsPages/Substance/SubstancePage.tsx
@@ -59,9 +59,9 @@ const SectionOneGlobalInformation = () => {
             rel="external noreferrer"
             target="_blank"
             className="text-primary"
-            href="https://assurance-maladie.ameli.fr/etudes-et-donnees/open-medic-base-complete-depenses-medicaments"
+            href="https://assurance-maladie.ameli.fr/etudes-et-donnees/open-medic-depenses-beneficiaires-medicaments"
           >
-            https://assurance-maladie.ameli.fr/etudes-et-donnees/open-medic-base-complete-depenses-medicaments
+            https://assurance-maladie.ameli.fr/etudes-et-donnees/open-medic-depenses-beneficiaires-medicaments
           </a>
         </p>
         <p>

--- a/src/componentsPages/Substance/SubstanceSideEffects.tsx
+++ b/src/componentsPages/Substance/SubstanceSideEffects.tsx
@@ -116,7 +116,7 @@ export const SubstanceSideEffects = ({
       <BoxInfo
         title={`${
           numberWithThousand(substance.sideEffects?.declarations?.total ?? 0) ?? 'Aucune'
-        } déclarations reçues pour : ${substance.name}`}
+        } déclarations reçues pour ${substance.name}`}
         icon={<FolderSVG className="h-24 w-24" />}
         theme="secondary"
         className="my-8"

--- a/src/componentsPages/Substance/SubstanceSideEffects.tsx
+++ b/src/componentsPages/Substance/SubstanceSideEffects.tsx
@@ -116,7 +116,7 @@ export const SubstanceSideEffects = ({
       <BoxInfo
         title={`${
           numberWithThousand(substance.sideEffects?.declarations?.total ?? 0) ?? 'Aucune'
-        } déclarations reçues`}
+        } déclarations reçues pour : ${substance.name}`}
         icon={<FolderSVG className="h-24 w-24" />}
         theme="secondary"
         className="my-8"

--- a/src/componentsPages/Substance/SubstanceSideEffects.tsx
+++ b/src/componentsPages/Substance/SubstanceSideEffects.tsx
@@ -121,8 +121,8 @@ export const SubstanceSideEffects = ({
         theme="secondary"
         className="my-8"
       >
-        Nombre cumulé de déclarations d&lsquo;effets indésirables suspectés d’être dus à un
-        médicament{' '}
+        Nombre cumulé de déclarations d&lsquo;effets indésirables suspectés d’être dus à cette
+        substance active{' '}
         {substance.sideEffects?.bnpvPeriod?.minYear &&
           substance.sideEffects?.bnpvPeriod?.maxYear &&
           `sur la période ${substance.sideEffects?.bnpvPeriod?.minYear} - ${substance.sideEffects?.bnpvPeriod?.maxYear}`}

--- a/src/config/layoutConfig.ts
+++ b/src/config/layoutConfig.ts
@@ -60,7 +60,7 @@ export const footerLinks: NavLinkItem[] = [
       },
       {
         title: 'CNAM',
-        url: 'https://assurance-maladie.ameli.fr/etudes-et-donnees/open-medic-base-complete-depenses-medicaments',
+        url: 'https://assurance-maladie.ameli.fr/etudes-et-donnees/open-medic-depenses-beneficiaires-medicaments',
       },
     ],
   },

--- a/src/graphql/__generated__/generated-documents.ts
+++ b/src/graphql/__generated__/generated-documents.ts
@@ -394,7 +394,7 @@ export type Speciality = {
 
 export type SpecialityAssociatedShortage = {
   __typename?: 'SpecialityAssociatedShortage';
-  cause?: Maybe<SpecialityRuptureCause>;
+  cause?: Maybe<Scalars['String']>;
   cis?: Maybe<ShortageCis>;
   classification?: Maybe<Scalars['String']>;
   date?: Maybe<Scalars['String']>;
@@ -655,16 +655,12 @@ export type SpecialityFragmentFragment = {
       date?: string | null;
       year?: number | null;
       classification?: string | null;
+      cause?: string | null;
       cis?: {
         __typename?: 'ShortageCis';
         id: number;
         code?: string | null;
         name?: string | null;
-      } | null;
-      cause?: {
-        __typename?: 'SpecialityRuptureCause';
-        type?: string | null;
-        definition?: string | null;
       } | null;
     }> | null;
     meta?: { __typename?: 'Meta'; count?: number | null } | null;
@@ -920,16 +916,12 @@ export type SpecialityQuery = {
         date?: string | null;
         year?: number | null;
         classification?: string | null;
+        cause?: string | null;
         cis?: {
           __typename?: 'ShortageCis';
           id: number;
           code?: string | null;
           name?: string | null;
-        } | null;
-        cause?: {
-          __typename?: 'SpecialityRuptureCause';
-          type?: string | null;
-          definition?: string | null;
         } | null;
       }> | null;
       meta?: { __typename?: 'Meta'; count?: number | null } | null;
@@ -1367,10 +1359,7 @@ export const SpecialityFragmentFragmentDoc = gql`
           name
         }
         classification
-        cause {
-          type
-          definition
-        }
+        cause
       }
       meta {
         count

--- a/src/graphql/__generated__/generated-documents.ts
+++ b/src/graphql/__generated__/generated-documents.ts
@@ -199,7 +199,9 @@ export type MutationLoginArgs = {
 
 export type Period = {
   __typename?: 'Period';
+  maxMonth?: Maybe<Scalars['String']>;
   maxYear: Scalars['Int'];
+  minMonth?: Maybe<Scalars['String']>;
   minYear: Scalars['Int'];
 };
 
@@ -639,7 +641,13 @@ export type SpecialityFragmentFragment = {
   } | null;
   shortagesHistory?: {
     __typename?: 'SpecialityRupturesHistory';
-    trustMedPeriod?: { __typename?: 'Period'; minYear: number; maxYear: number } | null;
+    trustMedPeriod?: {
+      __typename?: 'Period';
+      minMonth?: string | null;
+      minYear: number;
+      maxMonth?: string | null;
+      maxYear: number;
+    } | null;
     shortages?: Array<{
       __typename?: 'SpecialityAssociatedShortage';
       num?: string | null;
@@ -898,7 +906,13 @@ export type SpecialityQuery = {
     } | null;
     shortagesHistory?: {
       __typename?: 'SpecialityRupturesHistory';
-      trustMedPeriod?: { __typename?: 'Period'; minYear: number; maxYear: number } | null;
+      trustMedPeriod?: {
+        __typename?: 'Period';
+        minMonth?: string | null;
+        minYear: number;
+        maxMonth?: string | null;
+        maxYear: number;
+      } | null;
       shortages?: Array<{
         __typename?: 'SpecialityAssociatedShortage';
         num?: string | null;
@@ -1337,7 +1351,9 @@ export const SpecialityFragmentFragmentDoc = gql`
     }
     shortagesHistory {
       trustMedPeriod {
+        minMonth
         minYear
+        maxMonth
         maxYear
       }
       shortages {

--- a/src/graphql/queries.graphql
+++ b/src/graphql/queries.graphql
@@ -104,7 +104,9 @@ fragment SpecialityFragment on Speciality {
     }
     shortagesHistory {
         trustMedPeriod {
+            minMonth
             minYear
+            maxMonth
             maxYear
         }
         shortages {

--- a/src/graphql/queries.graphql
+++ b/src/graphql/queries.graphql
@@ -120,10 +120,7 @@ fragment SpecialityFragment on Speciality {
                 name
             }
             classification
-            cause {
-                type
-                definition
-            }
+            cause
         }
         meta {
             count


### PR DESCRIPTION
Cette PR a pour but d'apporter les évolutions simples de data.ansm.

Elle comprend la réalisation des tâches suivantes : 
[DATS-396](https://dataoffice-ansm.atlassian.net/browse/DATS-396) : Ajout du mois de mai dans la période d'historique des Ruptures de stock de la page spécialité